### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ A utility for managing content on your pelican blog. It indexes and makes your c
 [![Build Status](https://travis-ci.org/dandesousa/lapis.svg?branch=master)](http://travis-ci.org/dandesousa/lapis) 
 [![Coverage Status](https://coveralls.io/repos/dandesousa/lapis/badge.svg)](https://coveralls.io/r/dandesousa/lapis)
 
-[![Latest Version](https://pypip.in/version/lapis/badge.svg)](https://pypi.python.org/pypi/lapis/)
-[![Development Status](https://pypip.in/status/lapis/badge.svg)](https://pypi.python.org/pypi/lapis/)
-[![Wheel Status](https://pypip.in/wheel/lapis/badge.svg)](https://pypi.python.org/pypi/lapis/)
+[![Latest Version](https://img.shields.io/pypi/v/lapis.svg)](https://pypi.python.org/pypi/lapis/)
+[![Development Status](https://img.shields.io/pypi/status/lapis.svg)](https://pypi.python.org/pypi/lapis/)
+[![Wheel Status](https://img.shields.io/pypi/wheel/lapis.svg)](https://pypi.python.org/pypi/lapis/)
 
-[![Supported Python implementations](https://pypip.in/implementation/lapis/badge.svg)](https://pypi.python.org/pypi/lapis/)
-[![Supported Python versions](https://pypip.in/py_versions/lapis/badge.svg)](https://pypi.python.org/pypi/lapis/)
+[![Supported Python implementations](https://img.shields.io/pypi/implementation/lapis.svg)](https://pypi.python.org/pypi/lapis/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/lapis.svg)](https://pypi.python.org/pypi/lapis/)
 
-[![Downloads](https://pypip.in/download/lapis/badge.svg?period=month)](https://pypi.python.org/pypi/lapis/)
+[![Downloads](https://img.shields.io/pypi/dm/lapis.svg)](https://pypi.python.org/pypi/lapis/)
 
-[![License](https://pypip.in/license/lapis/badge.svg)](https://pypi.python.org/pypi/lapis/)
+[![License](https://img.shields.io/pypi/l/lapis.svg)](https://pypi.python.org/pypi/lapis/)
 
 ## Documentation
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20lapis))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `lapis`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.